### PR TITLE
config.toml: update Google Analytics ID for GA4 migration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,4 +5,4 @@ theme = "wwtguide"
 
 [extra]
 github_base = "https://github.com/WorldWideTelescope/worldwide-telescope-manual"
-google_analytics_id = "UA-107473046-3"
+google_analytics_id = "G-D1J49XX0CV"


### PR DESCRIPTION
More Google Analytics 4 migration. For a comprehensive set of all PR's, see:

https://github.com/WorldWideTelescope/wwt-website/pull/305